### PR TITLE
Fix source-URL in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -17,7 +17,7 @@
    "perl" : "6.c",
    "build-depends" : [],
    "auth" : "github:drforr",
-   "source-url" : "https://github.com/drfor/perl6-Inline-Scheme-Guile",
+   "source-url" : "https://github.com/drforr/perl6-Inline-Scheme-Guile.git",
    "resources" : [ "libraries/guile-helper" ],
    "depends" : [
       "LibraryMake"


### PR DESCRIPTION
as is, it's a 404, and breaks perl6-all-modules updating :(